### PR TITLE
show subpage titles in top tree items and fix some build warnings

### DIFF
--- a/docs/customer_support/howto_index.rst
+++ b/docs/customer_support/howto_index.rst
@@ -3,6 +3,5 @@ How TO
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    ipxe_boot_settings

--- a/docs/dev_guide/index.rst
+++ b/docs/dev_guide/index.rst
@@ -3,7 +3,6 @@ Development Guide
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    Repositories <repositories>
    API Versioning Conventions <api_versioning>

--- a/docs/extend_service/index.rst
+++ b/docs/extend_service/index.rst
@@ -3,7 +3,6 @@ Extended Services
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    TFTP and DHCP Service <tftp_dhcp_server>
    Static File Service <static_file_server>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,9 +45,6 @@ Contents
    dev_guide/index
    rackhd_vlab/index
    customer_support/index
-   ..
-        //Remove "solution center" section at present and will get it online after content prepared
-        solution_center/index
    contributing
 
 RackHD is a Trademark of Dell EMC Corporation.

--- a/docs/quick_guide.rst
+++ b/docs/quick_guide.rst
@@ -198,7 +198,7 @@ You can move on the guide or revisit previous sessions, then go back after 4~5 m
 
 
 Login Installed OS
--------------
+-----------------------------
 
 Once the OS has been installed, you can try login the system via UltraVNC console.
 Installed OS default username/password: ``root/RackHDRocks!``

--- a/docs/rackhd_api/features_index.rst
+++ b/docs/rackhd_api/features_index.rst
@@ -3,6 +3,5 @@ Features
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    features_ssdp

--- a/docs/rackhd_api/index.rst
+++ b/docs/rackhd_api/index.rst
@@ -3,7 +3,6 @@ RackHD API, Data Model, Feature
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    API Overview <api_overview>
    Data Model <data_model>

--- a/docs/redfish_api/index.rst
+++ b/docs/redfish_api/index.rst
@@ -3,7 +3,6 @@ Redfish API, Data Model, Feature
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    API Overview <api_overview>
    Data Model <data_model>

--- a/docs/run_rackhd/index.rst
+++ b/docs/run_rackhd/index.rst
@@ -3,7 +3,6 @@ Running RackHD
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    Deployment <deployment>
    installation

--- a/docs/server_workflow/index.rst
+++ b/docs/server_workflow/index.rst
@@ -3,7 +3,6 @@ Server Workflow Guide
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    Discovery <discovery_index>
    os-install/index

--- a/docs/switch_workflow/index.rst
+++ b/docs/switch_workflow/index.rst
@@ -3,6 +3,5 @@ Switch Workflow Guide
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    Discovery <discovery_index>

--- a/docs/tech_inside/index.rst
+++ b/docs/tech_inside/index.rst
@@ -3,7 +3,6 @@ Technical Inside
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    theory_of_ops
    software_arch

--- a/docs/web_ui/index.rst
+++ b/docs/web_ui/index.rst
@@ -3,7 +3,6 @@ RackHD Web-UI
 
 .. toctree::
    :titlesonly:
-   :hidden:
 
    web_ui_10
 


### PR DESCRIPTION
show subpage titles in top tree items and fix some build warnings